### PR TITLE
Allow environment variables to be injected into the docker build map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ A Leiningen plugin to build and deploy [Docker](https://www.docker.com/) images.
 Add docker-deploy to your plugin list in your `project.clj`:
 
 ```clojure
-:plugins [[gorillalabs/lein-docker "1.3.0"]]
+:plugins [[gorillalabs/lein-docker "1.6.0"]]
 ```
 
 (see version badge above for newest release)
 
 Available commands:
 
-    $ lein docker build
-    $ lein docker push
-    $ lein docker rmi
+    $ lein docker build [image-name [additional-arguments ... ]]
+    $ lein docker push [image-name]
+    $ lein docker rmi [image-name]
 
 ## Configuration
 
@@ -37,6 +37,24 @@ Defaults:
 * `:tags` is your project's version
 * `:dockerfile` points to `Dockerfile`
 * `:build-dir` points to the project's root
+
+### Injecting environment variables into configuration
+
+With a CI/CD pipeline such as Jenkins, you may want to generate Docker artifacts tagged
+against specific properties of a build run. The values in the :docker configuration options
+may contain bash-like references to environment variables, which will be replaced with
+values from the environment.  For example:
+
+```clojure
+:docker {:image-name "myregistry.example.org/myimage"
+         :tags ["%s-${BUILD_NUMBER:-unknown}"]}
+```
+
+Running `lein docker build` command under Jenkiuns line will generate an image tagged with the
+project number and build number (e.g., 1.6.0-306).  If BUILD_NUMBER is undefined, as when
+outside of Jenkins, then the default value ("unknown") will be spliced in instead.  Environment
+variable injection is supported for the `:image-name`, `:tags`, `:dockerfile`, and `:build-dir`
+entries in the project's `:docker` map.
 
 ## Releasing your docker images
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ values from the environment.  For example:
          :tags ["%s-${BUILD_NUMBER:-unknown}"]}
 ```
 
-Running `lein docker build` command under Jenkiuns line will generate an image tagged with the
+Running `lein docker build` command under Jenkins line will generate an image tagged with the
 project number and build number (e.g., 1.6.0-306).  If BUILD_NUMBER is undefined, as when
-outside of Jenkins, then the default value ("unknown") will be spliced in instead.  Environment
-variable injection is supported for the `:image-name`, `:tags`, `:dockerfile`, and `:build-dir`
-entries in the project's `:docker` map.
+outside of Jenkins, then the default value ("unknown") will be spliced in instead.  If the
+environment variable expression does not contain a default string and the referenced
+environment variable is not defined, the expression is replaced with the empty string.
+
+Environment variable injection is supported for the `:image-name`, `:tags`, `:dockerfile`,
+and `:build-dir` entries in the project's `:docker` map.
 
 ## Releasing your docker images
 


### PR DESCRIPTION
Thanks for taking my last pull request.  This one's just slightly more interesting.  We want our docker containers to be tagged with some build number information, as coming from Jenkins' `BUILD_NUMBER` environment variable for example.  This way, we can tag containers with both project-name:version and project-name:version-build.  Our CD pipeline picks the latest docker images labelled against the desired branch and tagged with a tag that matches a "major.minor.patch-build" pattern, and sends updated name:tag values to Helm, to perform a rolling update on our K8s cluster.  When we're happy with the state of a container, we push it out for use, without the -BUILD number part of the tag.

So... this change adds the ability to have something like this in the `:docker` configuration:

```clojure
:docker {:image-name "myregistry.example.org/myimage"
         :tags ["%s" "%s-${BUILD_NUMBER:-unknown}"]}
```
The syntax is similar to the way one dereferences a variable in bash with defaulting.  The resulting container will be tagged with the version number and with the version number and build number appended.    If used in a context where the environment variable is not defined, the default is used.  If there is no default, an empty string is substituted.

For completeness, environment variables can be injected into `:image-name`, `:version`, `:dockerfile`, and `:build-dir` in the `:docker` configuration map.